### PR TITLE
add basic information for employees about joining our Organizations

### DIFF
--- a/EMPLOYEE.md
+++ b/EMPLOYEE.md
@@ -1,0 +1,12 @@
+### Information for Esri employees
+
+In order to be added to one of our organizations (so that you'll appear [here](https://github.com/orgs/Esri/people))
+
+1. Create a new GitHub account
+  * Account: `jDoe` (*not* `jDoe-esri`)
+  * Name: `Jane Doe`
+  * Company: `Esri`
+  * A [Gravatar](https://help.github.com/articles/how-do-i-set-up-my-profile-picture/) is strongly recommended
+2. Use your `@esri.com` email address to send a message to `github_admin@esri.com` requesting to join our Organizations.
+
+The [Esri Organization](https://github.com/Esri) is for repositories that we want to make available to the public.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Contributing to Esri Open Source Projects
 =========================================
 
-Esri welcomes contributions to our [open source projects on Github](http://esri.github.io/). 
+Esri welcomes contributions to our [open source projects on Github](http://esri.github.io/).
 
 Issues
 ------
@@ -23,7 +23,7 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 Copyright and Licensing
 -----------------------
 
-Most Esri open source projects are licensed under the Apache 2.0 license. 
+Most Esri open source projects are licensed under the Apache 2.0 license.
 
 Esri does not require you to assign the copyright of your contributions, you retain the copyright. Esri does require that you make your contributions available under the Apache license in order to be included in the main repo.
 
@@ -51,5 +51,9 @@ limitations under the License.
 
 ### Contributing code written by others
 
-Please do not contribute code you did not write yourself, unless you are certain you have the legal ability to do so. Also ensure all code contributed can be licensed under the Apache License 2.0.
+Please do **not** contribute code you did not write yourself, unless you are certain you have the legal ability to do so. Also ensure all contributed code can be distributed under the Apache License 2.0.
+
+### Information for Esri employees
+
+More information for Esri employees interested in participating on Github can be found [here](EMPLOYEE.md).
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If appropriate, include the Apache 2.0 license summary at the top of each file a
 You can copy and paste the Apache 2.0 license summary from below.
 
 ```
-Copyright 2013 by Esri
+Copyright 2015 by Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
when assisting employees interested in joining our GitHub organizations, i notice they are rarely able to track down the information [here](http://devinfo/sites/DeveloperCentral/github/SitePages/GettingStarted.aspx) on their own to find out what is required.

i thought it'd be helpful to be able to share the information directly in our `contributing` repository.